### PR TITLE
Add support for Gentoo ebuild files

### DIFF
--- a/src/main/java/prettify/parser/Prettify.java
+++ b/src/main/java/prettify/parser/Prettify.java
@@ -268,7 +268,7 @@ public class Prettify {
       decorateSourceMap.put("keywords", SH_KEYWORDS);
       decorateSourceMap.put("hashComments", true);
       decorateSourceMap.put("multiLineStrings", true);
-      registerLangHandler(sourceDecorator(decorateSourceMap), Arrays.asList(new String[]{"bash", "bsh", "csh", "sh"}));
+      registerLangHandler(sourceDecorator(decorateSourceMap), Arrays.asList(new String[]{"bash", "bsh", "csh", "ebuild", "eclass", "sh"}));
 
       decorateSourceMap = new HashMap<String, Object>();
       decorateSourceMap.put("keywords", PYTHON_KEYWORDS);


### PR DESCRIPTION
Gentoo ebuild files are shell scripts so treat them as shell files when doing syntax highlighting.